### PR TITLE
Updated django caches import

### DIFF
--- a/cachelock.py
+++ b/cachelock.py
@@ -59,8 +59,8 @@ try:
 except ModuleNotFoundError:
     default_cache = MemoryCache()
 else:
-    from django.core.cache import cache
-    default_cache = cache[getattr(
+    from django.core.cache import caches
+    default_cache = caches[getattr(
         settings,
         'DEFAULT_CACHELOCK_ALIAS',
         'default'


### PR DESCRIPTION
`from django.core.cache import cache` cache is not subscriptable.
Django stores all configured caches in `caches` variable which is being imported from the same module